### PR TITLE
docs: add emoji and fix serveur wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Fleet Local
 
-Ce dépôt contient le script `fleetshare_ws.py` permettant d'envoyer les données MAVLink vers le service FleetShare.
+Ce dépôt contient le script `fleetshare_ws.py` permettant d'envoyer les données MAVLink vers mon serveur FleetShare 🚀.
 
-## Prérequis
+## Prérequis 📦
 
 - Python 3.8 ou supérieur installé sur votre machine. Vous pouvez le télécharger sur [python.org](https://www.python.org/downloads/).
 - Une connexion Internet pour installer les dépendances Python.
 
-## Installation et exécution sous Windows PowerShell
+## Installation et exécution sous Windows PowerShell 💻
 
 1. Ouvrez **Windows PowerShell**.
 2. Positionnez-vous dans le répertoire du projet :
@@ -23,14 +23,24 @@ Ce dépôt contient le script `fleetshare_ws.py` permettant d'envoyer les donné
    ```powershell
    pip install -r requirements.txt
    ```
-5. Lancez le script :
+5. Lancez le script depuis un terminal 🖥️:
    ```powershell
    python fleetshare_ws.py
    ```
 
 Le script se connecte au flux MAVLink fourni par `WS_URI` et envoie périodiquement les données au serveur HTTP configuré.
 
-## Utilisation en vol
+## Messages d'erreur ⚠️
+
+En cas de message d'erreur ou de blocage du script, tentez les étapes suivantes :
+
+1. Appuyez sur **CTRL+W** pour tuer le script dans la console. 🛑
+2. Utilisez la **flèche du haut** pour rappeler la commande précédente. ⬆️
+3. Appuyez sur **Entrée** pour relancer le script. 🔁
+
+Si les erreurs persistent, vérifiez votre connexion Internet et les paramètres `WS_URI` et `HTTP_ENDPOINT`.
+
+## Utilisation en vol ✈️
 
 Le streamer doit rester **lancé pendant tout le vol** afin de continuer d'envoyer
 les informations télémétriques. Ces informations sont disponibles sous forme
@@ -41,3 +51,4 @@ sur la carte à l'adresse <https://fleetshare.onrender.com>.
 Si le streamer est connecté lorsque le pilote envoie la commande « Lecture PN »,
 il récupère alors les *waypoints* de la mission et les affiche également sur
 l'interface web.
+

--- a/fleetshare_ws.py
+++ b/fleetshare_ws.py
@@ -1,3 +1,10 @@
+"""
+Ce script se connecte à un flux MAVLink via WebSocket et transmet périodiquement
+les données au serveur FleetShare.
+Créateur : AlexisMGL
+Dernière modification : 31 juillet 2025
+"""
+
 import asyncio
 import requests
 import websockets


### PR DESCRIPTION
## Summary
- replace "server" with "serveur" wording in README
- add contextual emojis for prerequisites, execution, and error handling

## Testing
- `python -m py_compile fleetshare_ws.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7f40ced448320ac8ba24dcbdcc6cb